### PR TITLE
Instantiate menuInterface earlier to avoid race condition

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,7 @@ export class Accessibility implements IAccessibility {
     constructor(options = {} as IAccessibilityOptions) {
         this._common = new Common();
         this._storage = new Storage();
+        this.menuInterface = new MenuInterface(this);
         this._fixedDefaultFont = this._common.getFixedFont('Material Icons');
         this._options = this.defaultOptions;
         this.options = this._common.extend(this._options, options);
@@ -1769,7 +1770,6 @@ export class Accessibility implements IAccessibility {
             document.getElementById('access_read_guide_bar').style.top = (newPos - (parseInt(this.options.guide.height.replace('px', '')) + 5)) + 'px';
         };
 
-        this.menuInterface = new MenuInterface(this);
         if (this.options.session.persistent)
             this.setSessionFromCache();
     }


### PR DESCRIPTION
When trying to overwrite a menu element via something like this:

```ts
var instance = new Accessibility();
instance.menuInterface.increaseText = function() {
    // My own way to increase text size . . .
}
```

I had the problem that I got the error "Cannot set properties of undefined", because it seems menuInterface had not been created when I tried to call the code, because it is created in the "build" method of the class Accessibility which is called in an async way. Looking through the code I did not find a reason why menuInterface is not just defined early in the constructor (maybe in the past there was a reason why it was initialized this late, but that reason is not around anymore?).

So I suggest to just create the object early on and not in an async method in order to make overwriting menu items work as suggested in the manual - currently I guess it is a race condition, but I would assume it usually fails, as it fails every time on my project. If I run the same code 2 seconds later it works fine.