### PR TITLE
Fix reset lineHeight

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1465,6 +1465,8 @@ export class Accessibility implements IAccessibility {
                     inPercent = inPercent + factor;
                     (all[i] as HTMLElement).style.lineHeight = inPercent + '%';
                 }
+                if (typeof this._stateValues.body.lineHeight === 'undefined')
+                    this._stateValues.body.lineHeight = '';
                 if (this._stateValues.textToSpeech) this.textToSpeech(`Line height ${isIncrease ? 'Increased' : 'Decreased'}`);
             }
         }


### PR DESCRIPTION
Set state value for lineHeight to be able to reset it properly. Should fix https://github.com/ranbuch/accessibility/issues/65

Not sure if what exactly is needed for `textPixelMode`. So this is at most a partial fix, but hopefully point you in the right direction to get this fixed.
